### PR TITLE
Add showGridLines config.

### DIFF
--- a/src/Products/Common/Entity/Web/LoadDocumentEntity.cs
+++ b/src/Products/Common/Entity/Web/LoadDocumentEntity.cs
@@ -17,6 +17,10 @@ namespace GroupDocs.Viewer.MVC.Products.Common.Entity.Web
         [JsonProperty]
         private bool printAllowed = true;
 
+        ///Document Guid
+        [JsonProperty]
+        private bool showGridLines = true;
+
         public void SetPrintAllowed(bool allowed)
         {
             this.printAllowed = allowed;
@@ -25,6 +29,16 @@ namespace GroupDocs.Viewer.MVC.Products.Common.Entity.Web
         public bool GetPrintAllowed()
         {
             return this.printAllowed;
+        }
+
+        public void SetShowGridLines(bool show)
+        {
+            this.showGridLines = show;
+        }
+
+        public bool GetShowGridLines()
+        {
+            return this.showGridLines;
         }
 
         public void SetGuid(string guid)

--- a/src/Products/Common/Entity/Web/LoadDocumentEntity.cs
+++ b/src/Products/Common/Entity/Web/LoadDocumentEntity.cs
@@ -9,15 +9,15 @@ namespace GroupDocs.Viewer.MVC.Products.Common.Entity.Web
         [JsonProperty]
         private string guid;
 
-        ///list of pages        
+        ///List of pages
         [JsonProperty]
         private List<PageDescriptionEntity> pages = new List<PageDescriptionEntity>();
 
-        ///Document Guid
+        ///Print allowed
         [JsonProperty]
         private bool printAllowed = true;
 
-        ///Document Guid
+        ///Show grid lines
         [JsonProperty]
         private bool showGridLines = true;
 

--- a/src/Products/Viewer/Config/ViewerConfiguration.cs
+++ b/src/Products/Viewer/Config/ViewerConfiguration.cs
@@ -51,6 +51,9 @@ namespace GroupDocs.Viewer.MVC.Products.Viewer.Config
         [JsonProperty]
         private bool printAllowed = true;
 
+        [JsonProperty]
+        private bool showGridLines = true;
+
         /// <summary>
         /// Constructor
         /// </summary>
@@ -82,6 +85,7 @@ namespace GroupDocs.Viewer.MVC.Products.Viewer.Config
             saveRotateState = valuesGetter.GetBooleanPropertyValue("saveRotateState", saveRotateState);
             watermarkText = valuesGetter.GetStringPropertyValue("watermarkText", watermarkText);
             printAllowed = valuesGetter.GetBooleanPropertyValue("printAllowed", printAllowed);
+            showGridLines = valuesGetter.GetBooleanPropertyValue("showGridLines", showGridLines);
         }
 
         private static bool IsFullPath(string path)
@@ -220,6 +224,16 @@ namespace GroupDocs.Viewer.MVC.Products.Viewer.Config
         public bool GetPrintAllowed()
         {
             return printAllowed;
+        }
+
+        public void SetShowGridLines(bool showGridLines)
+        {
+            this.showGridLines = showGridLines;
+        }
+
+        public bool GetShowGridLines()
+        {
+            return showGridLines;
         }
     }
 }

--- a/src/Products/Viewer/Controllers/ViewerApiController.cs
+++ b/src/Products/Viewer/Controllers/ViewerApiController.cs
@@ -431,6 +431,7 @@ namespace GroupDocs.Viewer.MVC.Products.Viewer.Controllers
                 loadDocumentEntity.SetPages(pageData);
             }
             loadDocumentEntity.SetGuid(documentGuid);
+            loadDocumentEntity.SetShowGridLines(globalConfiguration.Viewer.GetShowGridLines());
             // return document description
             return loadDocumentEntity;
         }
@@ -543,7 +544,7 @@ namespace GroupDocs.Viewer.MVC.Products.Viewer.Controllers
                 options.PageNumber = pageNumber;
                 options.CountPagesToRender = 1;
             }
-            options.CellsOptions.ShowGridLines = true;
+            options.CellsOptions.ShowGridLines = globalConfiguration.Viewer.GetShowGridLines();
         }
 
         private void SetOptions(ImageOptions options, string password, int pageNumber)
@@ -571,7 +572,7 @@ namespace GroupDocs.Viewer.MVC.Products.Viewer.Controllers
                 options.PageNumber = pageNumber;
                 options.CountPagesToRender = 1;
             }
-            options.CellsOptions.ShowGridLines = true;
+            options.CellsOptions.ShowGridLines = globalConfiguration.Viewer.GetShowGridLines();
         }
     }
 }

--- a/src/configuration.yml
+++ b/src/configuration.yml
@@ -88,3 +88,7 @@ viewer:
   # Set false to ignore document print security
   # Set true to check document print security
   printAllowed: true
+  # Adds/removes grid lines in the excel documents
+  # presentation regardless of whether they are in
+  # the document itself or not
+  showGridLines: true


### PR DESCRIPTION
**Problem:**
We would like to manage showing the grid-lines of the excel documents.

**Solution:**
Now we are sending the `showGridLines` config to the UI for achieving this.

**Screenshots:**
_`showGridLines = false` in the back-end viewer config:_
![image](https://user-images.githubusercontent.com/17431807/72528303-ca09e380-387b-11ea-8846-546e41a09b0c.png)

_`showGridLines = true` in the back-end viewer config:_
![image](https://user-images.githubusercontent.com/17431807/72528341-db52f000-387b-11ea-99ea-f24698a845ef.png)

**Related PR:**
https://github.com/groupdocs-total/GroupDocs.Total-Angular/pull/157