### PR TITLE
Sending InternalServerError from catch blocks of the api-controller.

### DIFF
--- a/src/Products/Viewer/Controllers/ViewerApiController.cs
+++ b/src/Products/Viewer/Controllers/ViewerApiController.cs
@@ -129,7 +129,7 @@ namespace GroupDocs.Viewer.MVC.Products.Viewer.Controllers
             }
             catch (System.Exception ex)
             {
-                return Request.CreateResponse(HttpStatusCode.OK, new Resources().GenerateException(ex));
+                return Request.CreateResponse(HttpStatusCode.InternalServerError, new Resources().GenerateException(ex));
             }
         }
 
@@ -241,7 +241,7 @@ namespace GroupDocs.Viewer.MVC.Products.Viewer.Controllers
             catch (System.Exception ex)
             {
                 // set exception message
-                return Request.CreateResponse(HttpStatusCode.OK, new Resources().GenerateException(ex));
+                return Request.CreateResponse(HttpStatusCode.InternalServerError, new Resources().GenerateException(ex));
             }
         }
 
@@ -336,7 +336,7 @@ namespace GroupDocs.Viewer.MVC.Products.Viewer.Controllers
             catch (System.Exception ex)
             {
                 // set exception message
-                return Request.CreateResponse(HttpStatusCode.OK, new Resources().GenerateException(ex));
+                return Request.CreateResponse(HttpStatusCode.InternalServerError, new Resources().GenerateException(ex));
             }
         }
 
@@ -361,7 +361,7 @@ namespace GroupDocs.Viewer.MVC.Products.Viewer.Controllers
             catch (System.Exception ex)
             {
                 // set exception message
-                return Request.CreateResponse(HttpStatusCode.OK, new Resources().GenerateException(ex, loadDocumentRequest.password));
+                return Request.CreateResponse(HttpStatusCode.InternalServerError, new Resources().GenerateException(ex, loadDocumentRequest.password));
             }
         }
 
@@ -386,7 +386,7 @@ namespace GroupDocs.Viewer.MVC.Products.Viewer.Controllers
             catch (System.Exception ex)
             {
                 // set exception message
-                return Request.CreateResponse(HttpStatusCode.OK, new Resources().GenerateException(ex));
+                return Request.CreateResponse(HttpStatusCode.InternalServerError, new Resources().GenerateException(ex));
             }
         }
 


### PR DESCRIPTION
**Problem:**
It would be better to response with `InternalServerError` status from the catch blocks of the api-controller.

**Solution:**
`OK` status was replaced by `InternalServerError` in the catch blocks of the api-controller.

**Tests:**
Build&run the project, check that it works as expected.