### PR TITLE
Changed sequence of executing build targets.

### DIFF
--- a/src/GroupDocs.Viewer.MVC.csproj
+++ b/src/GroupDocs.Viewer.MVC.csproj
@@ -231,7 +231,7 @@
     <Error Condition="!Exists('..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.0\build\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.0\build\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Net.Compilers.1.0.0\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Net.Compilers.1.0.0\build\Microsoft.Net.Compilers.props'))" />
   </Target>
-  <Target Name="BeforeBuild">
+  <Target Name="BeforeBuild" DependsOnTargets="PrepareForBuild">
     <Exec WorkingDirectory="client\" Command="..\..\packages\Node-Kit.11.1.0.1\node\win\node.exe ..\..\packages\Node-Kit.11.1.0.1\npm\bin\npm-cli.js install" Condition=" '$(OS)' == 'Windows_NT' " />
     <Exec WorkingDirectory="client\" Command="..\..\packages\Node-Kit.11.1.0.1\node\win\node.exe ..\..\packages\Node-Kit.11.1.0.1\npm\bin\npm-cli.js run build  --scripts-prepend-node-path" Condition=" '$(OS)' == 'Windows_NT' " />
   </Target>


### PR DESCRIPTION
**Problem:**
We faced the situation where building of the Angular npm-package was started before downloading and installing the special Node-kit NuGet package which was created especially for building the Angular sources without having the installed Node.js on the target machine.

**Solution:**
In the project file was added special condition to change sequence of execution for build targets.